### PR TITLE
[FEAT] 회원가입, 로그인, 회원조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,16 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // JWT 토큰 관련
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // spring security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pedalgenie/vote/domain/auth/CustomUserDetails.java
+++ b/src/main/java/com/pedalgenie/vote/domain/auth/CustomUserDetails.java
@@ -1,0 +1,60 @@
+package com.pedalgenie.vote.domain.auth;
+
+import com.pedalgenie.vote.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    // 권한 객체 목록을 반환
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities(){
+        // 권한 목록
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        // 권한 추가
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        return authorities;
+    }
+    @Override
+    public String getPassword(){
+        return member.getPassword();
+    }
+    @Override
+    public String getUsername() {
+        return member.getUsername();
+    }
+
+    // memberId 얻는 메서드 추가
+    public Long getMemberId(){
+        return member.getMemberId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/pedalgenie/vote/domain/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/pedalgenie/vote/domain/auth/CustomUserDetailsService.java
@@ -1,0 +1,26 @@
+package com.pedalgenie.vote.domain.auth;
+
+import com.pedalgenie.vote.domain.member.entity.Member;
+import com.pedalgenie.vote.domain.member.repostiory.MemberRepository;
+import com.pedalgenie.vote.global.exception.CustomException;
+import com.pedalgenie.vote.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException{
+        final Member member= memberRepository.findByUsername(username)
+                .orElseThrow(()-> new CustomException(ErrorCode.NOT_EXISTS_MEMBER_NAME));
+
+        return new CustomUserDetails(member);
+    }
+
+}

--- a/src/main/java/com/pedalgenie/vote/domain/jwt/JwtUtil.java
+++ b/src/main/java/com/pedalgenie/vote/domain/jwt/JwtUtil.java
@@ -1,0 +1,65 @@
+package com.pedalgenie.vote.domain.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import static io.jsonwebtoken.SignatureAlgorithm.HS256;
+
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+
+    public JwtUtil(@Value("${jwt.secret}")final String secret) {
+//        final String algorithm = HS256.getValue();
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),"HmacSHA256");
+    }
+
+    public String createJwt(final String category,final String username, Long expiredMs){
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .setIssuedAt(new Date(System.currentTimeMillis())) // 발급 시간
+                .setExpiration(new Date(System.currentTimeMillis()+ expiredMs)) // 만료 시간
+                .signWith(secretKey, HS256)
+                .compact();
+    }
+
+    // 토큰에서 유저네임 추출 메서드
+    public String getUsername(final String token){
+        Claims claims= getPayload(token);
+        return claims.get("username", String.class);
+    }
+
+    // 토큰에서 카테고리(액세스, 리프레시) 추출 메서드
+    public String getCategory(final String token){
+        Claims claims= getPayload(token);
+        return claims.get("category", String.class);
+    }
+
+    // 토큰 만료 검사 메서드
+    public boolean isExpired(final String token){
+        return getPayload(token)
+                .getExpiration()
+                .before(new Date());
+    }
+
+    // 토큰 페이로드 메서드
+    private Claims getPayload(final String token){
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/pedalgenie/vote/domain/jwt/TokenValidator.java
+++ b/src/main/java/com/pedalgenie/vote/domain/jwt/TokenValidator.java
@@ -1,0 +1,20 @@
+package com.pedalgenie.vote.domain.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenValidator {
+    private final JwtUtil jwtUtil;
+
+    // 토큰 만료 여부 확인
+    public void validateTokenExpired(final String token){
+        try{
+            jwtUtil.isExpired(token);
+        }catch (ExpiredJwtException e){
+            throw new IllegalArgumentException(jwtUtil.getCategory(token)+" 토큰 만료");
+        }
+    }
+}

--- a/src/main/java/com/pedalgenie/vote/domain/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pedalgenie/vote/domain/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,91 @@
+package com.pedalgenie.vote.domain.jwt.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pedalgenie.vote.domain.jwt.JwtUtil;
+import com.pedalgenie.vote.domain.member.dto.LoginRequest;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    @PostConstruct
+    public void init() {
+        setAuthenticationManager(authenticationManager); // 명시적으로 AuthenticationManager 설정
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+        throws AuthenticationException {
+
+        LoginRequest loginRequest;
+
+        try {
+            ObjectMapper objectMapper=new ObjectMapper();
+
+            // JSON 요청 본문을 읽어 LoginRequestDto 객체로 변환
+            ServletInputStream inputStream = request.getInputStream();
+            String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+            loginRequest = objectMapper.readValue(messageBody, LoginRequest.class);
+
+            // 스프링 시큐리티에서 사용자의 인증 정보(username, password)를 검증하기 위해서는 token(dto)에 담아야 함
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                    new UsernamePasswordAuthenticationToken(loginRequest.username(), loginRequest.password());
+
+            // token에 담은 값들의 검증을 위해 AuthenticationManager로 전달 -> 검증 진행
+            return authenticationManager.authenticate(usernamePasswordAuthenticationToken);
+
+        } catch (IOException e) {
+            throw new RuntimeException("요청 바디 파싱 에러");
+        }
+    }
+
+    // 로그인 성공 시 실행하는 메서드 (JWT 토큰 발급)
+    @Override
+    protected void successfulAuthentication(final HttpServletRequest request, final HttpServletResponse response,
+                                                final FilterChain filterChain, final Authentication authResult)
+            throws IOException, ServletException{
+
+        // CustomUserDetails의 메서드에서 추출한 값
+        final String username = authResult.getName();
+
+        // 권한 목록에 있는 권한을 추출(ROLE_USER)
+        String role = authResult.getAuthorities()
+                .iterator()
+                .next()
+                .getAuthority();
+
+        // 토큰 생성
+        String access = jwtUtil.createJwt("access", username,1000L * 60 * 60 * 2); // 2시간
+
+        // 응답 설정: 헤더 key 값을 access로 설정
+        response.setHeader("access", access);
+        response.setStatus(HttpStatus.OK.value());
+
+        // 시큐리티 컨텍스트 홀더에 저장
+        SecurityContextHolder.getContext().setAuthentication(authResult);
+
+    }
+
+
+}
+

--- a/src/main/java/com/pedalgenie/vote/domain/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pedalgenie/vote/domain/jwt/filter/JwtAuthenticationFilter.java
@@ -3,6 +3,10 @@ package com.pedalgenie.vote.domain.jwt.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pedalgenie.vote.domain.jwt.JwtUtil;
 import com.pedalgenie.vote.domain.member.dto.LoginRequest;
+import com.pedalgenie.vote.domain.member.entity.Member;
+import com.pedalgenie.vote.domain.member.repostiory.MemberRepository;
+import com.pedalgenie.vote.global.exception.CustomException;
+import com.pedalgenie.vote.global.exception.ErrorCode;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -27,6 +31,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
 
     @PostConstruct
     public void init() {
@@ -46,6 +51,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             ServletInputStream inputStream = request.getInputStream();
             String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
             loginRequest = objectMapper.readValue(messageBody, LoginRequest.class);
+
 
             // 스프링 시큐리티에서 사용자의 인증 정보(username, password)를 검증하기 위해서는 token(dto)에 담아야 함
             UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
@@ -81,9 +87,28 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         response.setHeader("access", access);
         response.setStatus(HttpStatus.OK.value());
 
+        // 프론트에 넘겨주기 위한 JSON 응답
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"result\": \"로그인이 성공적으로 완료되었습니다.\"}");
+
         // 시큐리티 컨텍스트 홀더에 저장
         SecurityContextHolder.getContext().setAuthentication(authResult);
 
+    }
+
+    // 로그인 실패 시
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request,HttpServletResponse response,
+                                              AuthenticationException failed) throws IOException, ServletException {
+
+//        super.unsuccessfulAuthentication(request, response, failed);
+
+        // 프론트에 넘겨주기 위한 JSON 응답
+        response.setStatus(401);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"result\": \"로그인에 실패하였습니다.\"}");
     }
 
 

--- a/src/main/java/com/pedalgenie/vote/domain/jwt/filter/JwtValidationFilter.java
+++ b/src/main/java/com/pedalgenie/vote/domain/jwt/filter/JwtValidationFilter.java
@@ -67,6 +67,7 @@ public class JwtValidationFilter extends OncePerRequestFilter {
         // 해당 유저 정보 로드
         CustomUserDetails userDetails = new CustomUserDetails(member);
 
+
         // 인증 객체 생성(principal, credentials), 비밀번호는 인증 후 더 이상 필요하지 않으므로 null
         Authentication authToken =
                 new UsernamePasswordAuthenticationToken(userDetails,null, userDetails.getAuthorities());

--- a/src/main/java/com/pedalgenie/vote/domain/jwt/filter/JwtValidationFilter.java
+++ b/src/main/java/com/pedalgenie/vote/domain/jwt/filter/JwtValidationFilter.java
@@ -1,0 +1,77 @@
+package com.pedalgenie.vote.domain.jwt.filter;
+
+import com.pedalgenie.vote.domain.auth.CustomUserDetails;
+import com.pedalgenie.vote.domain.auth.CustomUserDetailsService;
+import com.pedalgenie.vote.domain.jwt.JwtUtil;
+import com.pedalgenie.vote.domain.jwt.TokenValidator;
+import com.pedalgenie.vote.domain.member.entity.Member;
+import com.pedalgenie.vote.domain.member.repostiory.MemberRepository;
+import com.pedalgenie.vote.global.exception.CustomException;
+import com.pedalgenie.vote.global.exception.ErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JwtValidationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final TokenValidator tokenValidator;
+    private final MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request,
+                                 final HttpServletResponse response,
+                                 final FilterChain filterChain)
+        throws ServletException, IOException{
+
+        // 헤더에서 access 키에 담긴 토큰을 꺼냄
+        String accessToken = request.getHeader("access");
+
+        // 토큰이 없다면 다음 필터로 넘김
+        if(!StringUtils.hasText(accessToken)){
+            filterChain.doFilter(request,response);
+            return;
+        }
+        // 토큰 만료 여부 확인, 만료 시 다음 필터로 넘기지 않음
+        tokenValidator.validateTokenExpired(accessToken);
+
+        // 인증 정보 저장
+        setAuthentication(accessToken);
+
+        filterChain.doFilter(request, response);
+
+    }
+
+    // jwt 토큰 사용해서 사용자 인증, SecurityContext 에 인증 정보 설정
+    private void setAuthentication(String accessToken){
+
+        // 토큰에서 유저 이름 추출
+        String username = jwtUtil.getUsername(accessToken);
+
+        // 유저 디비에서 이름 찾기
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(()-> new CustomException(ErrorCode.NOT_EXISTS_MEMBER_NAME));
+
+        // 해당 유저 정보 로드
+        CustomUserDetails userDetails = new CustomUserDetails(member);
+
+        // 인증 객체 생성(principal, credentials), 비밀번호는 인증 후 더 이상 필요하지 않으므로 null
+        Authentication authToken =
+                new UsernamePasswordAuthenticationToken(userDetails,null, userDetails.getAuthorities());
+
+        // 인증 정보 저장
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+}

--- a/src/main/java/com/pedalgenie/vote/domain/member/controller/AuthController.java
+++ b/src/main/java/com/pedalgenie/vote/domain/member/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.pedalgenie.vote.domain.member.controller;
+
+import com.pedalgenie.vote.domain.member.dto.SignUpRequest;
+import com.pedalgenie.vote.domain.member.dto.SignUpResponse;
+import com.pedalgenie.vote.domain.member.service.AuthService;
+import com.pedalgenie.vote.global.ResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService memberService;
+
+    @Operation(summary="회원가입")
+    @PostMapping
+    public ResponseEntity<ResponseTemplate<SignUpResponse>> signUp(@RequestBody final SignUpRequest request){
+        SignUpResponse signUpResponse = memberService.signUp(request);
+        return ResponseTemplate.createTemplate(HttpStatus.CREATED,true,"회원가입 성공",signUpResponse);
+    }
+
+
+}

--- a/src/main/java/com/pedalgenie/vote/domain/member/controller/MemberController.java
+++ b/src/main/java/com/pedalgenie/vote/domain/member/controller/MemberController.java
@@ -1,0 +1,32 @@
+package com.pedalgenie.vote.domain.member.controller;
+
+import com.pedalgenie.vote.domain.auth.CustomUserDetails;
+import com.pedalgenie.vote.domain.member.dto.SignUpResponse;
+import com.pedalgenie.vote.domain.member.service.MemberService;
+import com.pedalgenie.vote.global.ResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
+public class MemberController {
+    private final MemberService memberService;
+
+    @Operation(summary="회원 정보 조회")
+    @GetMapping
+    public ResponseEntity<ResponseTemplate<SignUpResponse>> memberInfo(@AuthenticationPrincipal CustomUserDetails userDetails){
+
+        Long memberId = userDetails.getMemberId();
+        SignUpResponse signUpResponse = memberService.getMemberInfo(memberId);
+        return ResponseTemplate.createTemplate(HttpStatus.OK,true,"회원 정보 조회 성공", signUpResponse);
+    }
+
+
+}

--- a/src/main/java/com/pedalgenie/vote/domain/member/dto/LoginRequest.java
+++ b/src/main/java/com/pedalgenie/vote/domain/member/dto/LoginRequest.java
@@ -1,0 +1,4 @@
+package com.pedalgenie.vote.domain.member.dto;
+
+public record LoginRequest(String username, String password) {
+}

--- a/src/main/java/com/pedalgenie/vote/domain/member/dto/LoginResponse.java
+++ b/src/main/java/com/pedalgenie/vote/domain/member/dto/LoginResponse.java
@@ -1,0 +1,6 @@
+package com.pedalgenie.vote.domain.member.dto;
+
+public record LoginResponse(
+
+) {
+}

--- a/src/main/java/com/pedalgenie/vote/domain/member/dto/SignUpRequest.java
+++ b/src/main/java/com/pedalgenie/vote/domain/member/dto/SignUpRequest.java
@@ -1,0 +1,26 @@
+package com.pedalgenie.vote.domain.member.dto;
+
+import com.pedalgenie.vote.domain.member.entity.Member;
+import com.pedalgenie.vote.domain.member.entity.Part;
+import com.pedalgenie.vote.domain.member.entity.Team;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public record SignUpRequest(
+        String loginId,
+        String password,
+        String email,
+        String username,
+        Part part,
+        Team team
+) {
+    public Member toEntity(PasswordEncoder passwordEncoder){
+        return Member.builder()
+                .loginId(loginId)
+                .password(passwordEncoder.encode(password))
+                .email(email)
+                .username(username)
+                .part(part)
+                .team(team)
+                .build();
+    }
+}

--- a/src/main/java/com/pedalgenie/vote/domain/member/dto/SignUpResponse.java
+++ b/src/main/java/com/pedalgenie/vote/domain/member/dto/SignUpResponse.java
@@ -1,0 +1,14 @@
+package com.pedalgenie.vote.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.pedalgenie.vote.domain.member.entity.Member;
+
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드 json에서 제외
+public record SignUpResponse(
+        String loginId,
+        String username
+) {
+    public static SignUpResponse from(Member member){
+        return new SignUpResponse(member.getLoginId(),member.getUsername());
+    }
+}

--- a/src/main/java/com/pedalgenie/vote/domain/member/entity/Member.java
+++ b/src/main/java/com/pedalgenie/vote/domain/member/entity/Member.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(name = "member")
 public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,7 +22,7 @@ public class Member extends BaseTimeEntity {
     private String loginId;
 
     @NotNull
-    private String name;
+    private String username;
 
     @NotNull
     private String email;
@@ -36,9 +37,9 @@ public class Member extends BaseTimeEntity {
     private Team team;
 
     @Builder
-    public Member(String loginId, String name, String email, String password, Part part, Team team) {
+    public Member(String loginId, String username, String email, String password, Part part, Team team) {
         this.loginId = loginId;
-        this.name = name;
+        this.username = username;
         this.email = email;
         this.password = password;
         this.part = part;

--- a/src/main/java/com/pedalgenie/vote/domain/member/repostiory/MemberRepository.java
+++ b/src/main/java/com/pedalgenie/vote/domain/member/repostiory/MemberRepository.java
@@ -2,6 +2,14 @@ package com.pedalgenie.vote.domain.member.repostiory;
 
 import com.pedalgenie.vote.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByLoginId(final String loginId);
+    boolean existsByEmail(final String email);
+
+    Optional<Member> findByUsername(String username);
 }

--- a/src/main/java/com/pedalgenie/vote/domain/member/service/AuthService.java
+++ b/src/main/java/com/pedalgenie/vote/domain/member/service/AuthService.java
@@ -1,0 +1,45 @@
+package com.pedalgenie.vote.domain.member.service;
+
+import com.pedalgenie.vote.domain.auth.CustomUserDetailsService;
+import com.pedalgenie.vote.domain.jwt.JwtUtil;
+import com.pedalgenie.vote.domain.member.dto.SignUpRequest;
+import com.pedalgenie.vote.domain.member.dto.SignUpResponse;
+import com.pedalgenie.vote.domain.member.entity.Member;
+import com.pedalgenie.vote.domain.member.repostiory.MemberRepository;
+import com.pedalgenie.vote.global.exception.CustomException;
+import com.pedalgenie.vote.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtil jwtUtil;
+
+
+    // 회원 가입
+    public SignUpResponse signUp(final SignUpRequest request){
+
+        // 로그인 아이디 중복 검사
+        if(memberRepository.existsByLoginId(request.loginId())){
+            throw new CustomException(ErrorCode.ALREADY_REGISTERED_LOGIN_ID);
+        }
+        // 이메일 중복 검사
+        if(memberRepository.existsByEmail(request.email())){
+            throw new CustomException(ErrorCode.ALREADY_REGISTERED_MEMBER_EMAIL);
+        }
+        final Member member = request.toEntity(passwordEncoder);
+        memberRepository.save(member);
+
+        return SignUpResponse.from(member);
+
+    }
+
+}

--- a/src/main/java/com/pedalgenie/vote/domain/member/service/MemberService.java
+++ b/src/main/java/com/pedalgenie/vote/domain/member/service/MemberService.java
@@ -1,0 +1,26 @@
+package com.pedalgenie.vote.domain.member.service;
+
+import com.pedalgenie.vote.domain.member.dto.SignUpResponse;
+import com.pedalgenie.vote.domain.member.entity.Member;
+import com.pedalgenie.vote.domain.member.repostiory.MemberRepository;
+import com.pedalgenie.vote.global.exception.CustomException;
+import com.pedalgenie.vote.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    // 회원 조회 메서드
+    public SignUpResponse getMemberInfo(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()->new CustomException(ErrorCode.NOT_EXISTS_MEMBER_ID));
+        return SignUpResponse.from(member);
+    }
+
+}

--- a/src/main/java/com/pedalgenie/vote/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/pedalgenie/vote/domain/vote/controller/VoteController.java
@@ -1,5 +1,6 @@
 package com.pedalgenie.vote.domain.vote.controller;
 
+import com.pedalgenie.vote.domain.auth.CustomUserDetails;
 import com.pedalgenie.vote.domain.vote.dto.VoteResultDto;
 import com.pedalgenie.vote.domain.vote.service.VoteService;
 import com.pedalgenie.vote.domain.vote.dto.VoteRequestDto;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,9 +29,10 @@ public class VoteController {
     public ResponseEntity<ResponseTemplate<VoteResponseDto>> createVote(
             @RequestParam String type,
             @RequestParam(required = false) String part,
-            @RequestParam String voted
+            @RequestParam String voted,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long memberId = 1L; // static, 추후 인증 정보로 변경 예정
+        Long memberId = userDetails.getMemberId(); // 인증 정보로 변경
 
         VoteRequestDto requestDto = VoteRequestDto.builder()
                 .type(type)

--- a/src/main/java/com/pedalgenie/vote/domain/vote/repository/LeaderVoteRepository.java
+++ b/src/main/java/com/pedalgenie/vote/domain/vote/repository/LeaderVoteRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
+
 public interface LeaderVoteRepository extends JpaRepository<LeaderVote, Long> {
     boolean existsByMember(Member member);
 

--- a/src/main/java/com/pedalgenie/vote/domain/vote/service/VoteService.java
+++ b/src/main/java/com/pedalgenie/vote/domain/vote/service/VoteService.java
@@ -75,7 +75,7 @@ public class VoteService {
         leaderVoteRepository.save(leaderVote);
 
         return VoteResponseDto.builder()
-                .voter(voter.getName())
+                .voter(voter.getUsername())
                 .voted(partMember)
                 .build();
     }
@@ -103,7 +103,7 @@ public class VoteService {
         teamVoteRepository.save(teamVote);
 
         return VoteResponseDto.builder()
-                .voter(voter.getName())
+                .voter(voter.getUsername())
                 .voted(votedTeam)
                 .build();
     }

--- a/src/main/java/com/pedalgenie/vote/global/config/SecurityConfig.java
+++ b/src/main/java/com/pedalgenie/vote/global/config/SecurityConfig.java
@@ -1,0 +1,80 @@
+package com.pedalgenie.vote.global.config;
+
+import com.pedalgenie.vote.domain.jwt.filter.JwtAuthenticationFilter;
+import com.pedalgenie.vote.domain.jwt.JwtUtil;
+import com.pedalgenie.vote.domain.jwt.filter.JwtValidationFilter;
+import com.pedalgenie.vote.domain.jwt.TokenValidator;
+import com.pedalgenie.vote.domain.member.repostiory.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtil jwtUtil;
+    private final TokenValidator tokenValidator;
+    private final MemberRepository memberRepository;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(HttpBasicConfigurer::disable);
+
+        http
+                // 접근 허용된 URI
+                .authorizeHttpRequests(auth ->auth
+                        .requestMatchers("/login",
+                                "/",
+                                "/api/auth").permitAll()
+                        .requestMatchers("/swwagger-ui/index.html",
+                                "/v3/api-docs/**").permitAll()
+                        .anyRequest().authenticated());
+
+        // AuthenticationManager 생성
+        AuthenticationManager authenticationManager = authenticationManager(authenticationConfiguration);
+
+        // JwtAuthenticationFilter 설정
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager, jwtUtil);
+        jwtAuthenticationFilter.setFilterProcessesUrl("/login"); // 로그인 URL 설정
+
+        // 필터 추가
+        http
+                .addFilterBefore(new JwtValidationFilter(jwtUtil, tokenValidator,memberRepository), JwtAuthenticationFilter.class)
+                .addFilterAt(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .sessionManagement((session)->session.sessionCreationPolicy(STATELESS));
+
+        return http.build();
+    }
+
+    // AuthenticationManager 빈 등록
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/pedalgenie/vote/global/config/SecurityConfig.java
+++ b/src/main/java/com/pedalgenie/vote/global/config/SecurityConfig.java
@@ -42,18 +42,15 @@ public class SecurityConfig {
         http
                 // 접근 허용된 URI
                 .authorizeHttpRequests(auth ->auth
-                        .requestMatchers("/login",
-                                "/",
-                                "/api/auth").permitAll()
-                        .requestMatchers("/swwagger-ui/index.html",
-                                "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/login", "/", "/api/auth").permitAll()
+                        .requestMatchers("/swwagger-ui/index.html", "/v3/api-docs/**", "http://localhost:3000/**").permitAll()
                         .anyRequest().authenticated());
 
         // AuthenticationManager 생성
         AuthenticationManager authenticationManager = authenticationManager(authenticationConfiguration);
 
         // JwtAuthenticationFilter 설정
-        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager, jwtUtil);
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager, jwtUtil,memberRepository);
         jwtAuthenticationFilter.setFilterProcessesUrl("/login"); // 로그인 URL 설정
 
         // 필터 추가

--- a/src/main/java/com/pedalgenie/vote/global/exception/ErrorCode.java
+++ b/src/main/java/com/pedalgenie/vote/global/exception/ErrorCode.java
@@ -30,11 +30,13 @@ public enum ErrorCode {
 
     // 404
     NOT_EXISTS_MEMBER_ID(HttpStatus.NOT_FOUND, 404, "존재하지 않는 멤버 아이디입니다."),
-    NOT_EXISTS_MEMBER_NICKNAME(HttpStatus.NOT_FOUND, 404, "존재하지 않는 멤버 닉네임입니다."),
+    NOT_EXISTS_MEMBER_NAME(HttpStatus.NOT_FOUND, 404, "존재하지 않는 멤버 이름입니다."),
     NOT_EXISTS_MEMBER_EMAIL(HttpStatus.NOT_FOUND, 404, "존재하지 않는 멤버 이메일입니다."),
+
 
     // 409
     ALREADY_REGISTERED_MEMBER_EMAIL(HttpStatus.CONFLICT, 409, "이미 가입된 이메일입니다."),
+    ALREADY_REGISTERED_LOGIN_ID(HttpStatus.CONFLICT,409,"이미 가입된 아이디입니다."),
     ALREADY_VOTED(HttpStatus.CONFLICT, 409,  "이미 투표한 유저의 요청입니다."),
 
     // 500

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,7 @@ spring:
       format_sql: true
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    dialect: org.hibernate.dialect.MySQL8Dialect  # 이 항목 추가
 jwt:
   secret: ${JWT}
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

---
## 📝 작업 내용
- 회원 가입 API
- 로그인 API
- 회원 조회 API

---
## 💬 리뷰 요구사항
#### 1. 투표 생성 API
- 투표 생성 API에 사용자 인증 정보 추가한 후 API 테스트 완료하였습니다. 수정하실 것 없습니다! 
#### 2. 액세스 토큰 
- 토큰 헤더의 키를 access로 하였고, 값에 bearer 포함하지 않았습니다. 
- 그래서 노션에 올라가 있는 투표 생성 Request 를 "Headers의 key 칸에 access를 입력하시고, value 칸에 발급받은 토큰을 넣어주세요"로 수정하였는데 아래 노션 링크 참고 부탁드립니다. 
- [노션](https://www.notion.so/u--x/bcb44d244d0345a6bfaa6fd29312ca22)
#### 3. 과제 요구사항 
아래 과제 요구사항 모두 만족하였습니다. 
- JWT 인증 
- 아이디 혹은 비밀번호가 틀렸을 시 에러를 반환
- 회원 가입 필드(아이디, 비밀번호, 이메일, 파트, 이름, 팀)
- 아이디, 이메일 중복 불가 로직 
---
## 🔗 레퍼런스
